### PR TITLE
Centralized tsconf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 !jest.config.js
 *.d.ts
 node_modules/
+.history/
 dist/
 yarn-error.log

--- a/packages/helloworld/package.json
+++ b/packages/helloworld/package.json
@@ -8,8 +8,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.101",
-    "typescript-package": "1.0.0"
+    "@types/aws-lambda": "^8.10.101"
   },
   "dependencies": {
     "moment": "^2.29.4"

--- a/packages/helloworld/tsconfig.json
+++ b/packages/helloworld/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "typescript-package/tsconfig.json"
+  "extends": "typescript-package/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
 }

--- a/packages/helloworld/tsconfig.json
+++ b/packages/helloworld/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  }
+  "extends": "typescript-package/tsconfig.json"
 }

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -12,8 +12,7 @@
   },
   "devDependencies": {
     "aws-cdk": "2.32.0",
-    "esbuild": "0",
-    "typescript-package": "1.0.0"
+    "esbuild": "0"
   },
   "dependencies": {
     "aws-cdk-lib": "2.32.0",

--- a/packages/infrastructure/tsconfig.json
+++ b/packages/infrastructure/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "typescript-package/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist"
   }


### PR DESCRIPTION
All packages are now based on typescript-package/tsconfig.json
There's only 1 limitation though, 

By design, we have to repeat the outDir for every package tsconfig.json
https://github.com/microsoft/TypeScript/issues/29172


[![Objects In The Rear View Mirror May Appear Closer Than They Are](https://img.youtube.com/vi/3jPMv9zJ1LE/0.jpg)](https://www.youtube.com/watch?v=3jPMv9zJ1LE)